### PR TITLE
Finish Login Attempt Listener

### DIFF
--- a/.idea/runConfigurations/FlashcardWars.xml
+++ b/.idea/runConfigurations/FlashcardWars.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="FlashcardWars" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <envs>
+      <env name="spring.datasource.username" value="bheck" />
+      <env name="spring.datasource.password" value="Romeo53078" />
+      <env name="spring.security.secret-key" value="secret" />
+    </envs>
+    <module name="flashcard.wars.main" />
+    <target name="@@@LOCAL@@@" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="study.games.flashcard.wars.Application" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/flashcard.wars/.gitignore
+++ b/flashcard.wars/.gitignore
@@ -24,4 +24,4 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-.idea
+.idea/**

--- a/flashcard.wars/build.gradle
+++ b/flashcard.wars/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.apache.commons:commons-lang3:3.0'
 	implementation 'org.modelmapper:modelmapper:3.2.0'
+	implementation 'com.google.guava:guava:33.2.0-jre'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/ApplicationConfig.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/ApplicationConfig.java
@@ -17,8 +17,6 @@ import study.games.flashcard.wars.auth.UserPrinciple;
 import study.games.flashcard.wars.models.entities.AppUser;
 import study.games.flashcard.wars.repository.UserRepository;
 
-import java.time.LocalDate;
-
 @Configuration
 @RequiredArgsConstructor
 public class ApplicationConfig {
@@ -31,8 +29,7 @@ public class ApplicationConfig {
             if(user == null) {
                 throw new UsernameNotFoundException("user not found: " + username);
             }
-            user.setLastLoginDate(LocalDate.now());
-            return new UserPrinciple(userRepo.save(user));
+            return new UserPrinciple(user);
         };
     }
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/UserPrinciple.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/UserPrinciple.java
@@ -20,7 +20,7 @@ public class UserPrinciple implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return appUser.getAuthorities().stream().map(permission ->
+        return appUser.getRole().getPermissions().stream().map(permission ->
                 new SimpleGrantedAuthority(permission.toString()))
                 .collect(Collectors.toList());
     }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/UserPrinciple.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/UserPrinciple.java
@@ -9,6 +9,7 @@ import study.games.flashcard.wars.models.enums.USER_STATUS;
 import study.games.flashcard.wars.models.entities.AppUser;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class UserPrinciple implements UserDetails {
 
     @Override
     public boolean isAccountNonExpired() {
-        LocalDate yearAgo = LocalDate.now().minusYears(1);
+        LocalDateTime yearAgo = LocalDateTime.now().minusYears(1);
         return appUser.getLastLoginDate().isAfter(yearAgo);
     }
 
@@ -48,7 +49,7 @@ public class UserPrinciple implements UserDetails {
 
     @Override
     public boolean isCredentialsNonExpired() {
-        LocalDate days120Ago = LocalDate.now().minusDays(120);
+        LocalDateTime days120Ago = LocalDateTime.now().minusDays(120);
         return appUser.getLastPasswordUpdate().isAfter(days120Ago);
     }
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/filters/JwtAuthorizationFilter.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/filters/JwtAuthorizationFilter.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import study.games.flashcard.wars.auth.JwtService;
+import study.games.flashcard.wars.auth.services.JwtService;
 import study.games.flashcard.wars.auth.SecurityConstants;
 
 import java.io.IOException;

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/AuthenticationService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/AuthenticationService.java
@@ -1,4 +1,4 @@
-package study.games.flashcard.wars.auth;
+package study.games.flashcard.wars.auth.services;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -9,11 +9,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import study.games.flashcard.wars.auth.UserPrinciple;
 import study.games.flashcard.wars.exception.domain.EmailExistsException;
 import study.games.flashcard.wars.exception.domain.UsernameExistsException;
 import study.games.flashcard.wars.models.dtos.UserDto;
 import study.games.flashcard.wars.models.entities.AppUser;
-import study.games.flashcard.wars.models.enums.ROLE;
 import study.games.flashcard.wars.models.enums.USER_STATUS;
 import study.games.flashcard.wars.repository.UserRepository;
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/AuthenticationService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/AuthenticationService.java
@@ -18,6 +18,7 @@ import study.games.flashcard.wars.models.enums.USER_STATUS;
 import study.games.flashcard.wars.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Base64;
 
 import static study.games.flashcard.wars.auth.SecurityConstants.JWT_HEADER;
@@ -35,11 +36,8 @@ public class AuthenticationService {
         String username = usernameAndPassword[0];
         String password = usernameAndPassword[1];
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
-        AppUser user = userRepository.findAppUserByUsernameOrEmail(username)
+        return userRepository.findAppUserByUsernameOrEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
-        user.setLastLoginDate(LocalDate.now());
-        user.setAuthorities(user.getRole().getPermissions());
-        return user;
     }
 
     public HttpHeaders getJwtTokenHeader(AppUser user) {
@@ -92,15 +90,14 @@ public class AuthenticationService {
 
     private AppUser createNewAppUser(UserDto userDto) {
         AppUser appUser = new AppUser();
-        appUser.setLastLoginDate(LocalDate.now());
+        appUser.setLastLoginDate(LocalDateTime.now());
         appUser.setUserId(generateUserId());
         appUser.setEmail(userDto.getEmail());
         appUser.setRole(userDto.getRole());
         appUser.setStatus(USER_STATUS.ACTIVE);
         appUser.setPassword(generatePassword(userDto.getPassword()));
         appUser.setUsername(userDto.getUsername());
-        appUser.setDateJoined(LocalDate.now());
-        appUser.setLastPasswordUpdate(LocalDate.now());
+        appUser.setLastPasswordUpdate(LocalDateTime.now());
         appUser.setAuthorities(userDto.getRole().getPermissions());
         appUser.setProfileImageUrl(getTemporaryProfileImage());
         appUser.setFirstName(userDto.getFirstName());

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/JwtService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/JwtService.java
@@ -1,4 +1,4 @@
-package study.games.flashcard.wars.auth;
+package study.games.flashcard.wars.auth.services;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
@@ -13,6 +13,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Service;
+import study.games.flashcard.wars.auth.UserPrinciple;
 import study.games.flashcard.wars.models.enums.PERMISSION;
 
 import java.util.ArrayList;

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -5,13 +5,14 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @Service
 public class LoginAttemptService {
     private static final int MAX_NUMBER_LOGIN_ATTEMPTS = 5;
     private static final int ATTEMPT_INCREMENT = 1;
-    private LoadingCache<String, Integer> loginAttemptCache;
+    private final LoadingCache<String, Integer> loginAttemptCache;
 
     public LoginAttemptService() {
         super();
@@ -28,5 +29,14 @@ public class LoginAttemptService {
 
     public void evictUserFromLoginAttemptCache(String usernameOrEmail) {
         loginAttemptCache.invalidate(usernameOrEmail);
+    }
+
+    public void addUserToLoginAttemptCache(String usernameOrEmail) throws ExecutionException {
+        int attempts = ATTEMPT_INCREMENT + loginAttemptCache.get(usernameOrEmail);
+        loginAttemptCache.put(usernameOrEmail, attempts);
+    }
+
+    public boolean hasExceededMaxAttempts(int attempts) throws ExecutionException {
+        return attempts >= MAX_NUMBER_LOGIN_ATTEMPTS;
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -4,6 +4,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.springframework.stereotype.Service;
+import study.games.flashcard.wars.exception.domain.AccountNotActiveException;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -31,12 +32,16 @@ public class LoginAttemptService {
         loginAttemptCache.invalidate(usernameOrEmail);
     }
 
-    public void addUserToLoginAttemptCache(String usernameOrEmail) throws ExecutionException {
+    public void addUserToLoginAttemptCache(String usernameOrEmail) throws ExecutionException, AccountNotActiveException {
         int attempts = ATTEMPT_INCREMENT + loginAttemptCache.get(usernameOrEmail);
-        loginAttemptCache.put(usernameOrEmail, attempts);
+        if(hasExceededMaxAttempts(attempts)) {
+            throw new AccountNotActiveException("account with username or email" + usernameOrEmail + " has exceeded login attempts.");
+        } else {
+            loginAttemptCache.put(usernameOrEmail, attempts);
+        }
     }
 
-    public boolean hasExceededMaxAttempts(int attempts) throws ExecutionException {
+    private boolean hasExceededMaxAttempts(int attempts) {
         return attempts >= MAX_NUMBER_LOGIN_ATTEMPTS;
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -1,0 +1,30 @@
+package study.games.flashcard.wars.auth.services;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class LoginAttemptService {
+    private static final int MAX_NUMBER_LOGIN_ATTEMPTS = 5;
+    private static final int ATTEMPT_INCREMENT = 1;
+    private LoadingCache<String, Integer> loginAttemptCache;
+
+    public LoginAttemptService() {
+        super();
+        loginAttemptCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(15, TimeUnit.MINUTES)
+                .maximumSize(100)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public Integer load(String key) {
+                        return 0;
+                    }
+                });
+    }
+
+
+}

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -3,9 +3,7 @@ package study.games.flashcard.wars.auth.services;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import study.games.flashcard.wars.service.UserService;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -26,5 +26,7 @@ public class LoginAttemptService {
                 });
     }
 
-
+    public void evictUserFromLoginAttemptCache(String usernameOrEmail) {
+        loginAttemptCache.invalidate(usernameOrEmail);
+    }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -3,7 +3,9 @@ package study.games.flashcard.wars.auth.services;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import study.games.flashcard.wars.service.UserService;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/auth/services/LoginAttemptService.java
@@ -3,8 +3,8 @@ package study.games.flashcard.wars.auth.services;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.stereotype.Service;
-import study.games.flashcard.wars.exception.domain.AccountNotActiveException;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -32,10 +32,10 @@ public class LoginAttemptService {
         loginAttemptCache.invalidate(usernameOrEmail);
     }
 
-    public void addUserToLoginAttemptCache(String usernameOrEmail) throws ExecutionException, AccountNotActiveException {
+    public void addUserToLoginAttemptCache(String usernameOrEmail) throws ExecutionException, LockedException {
         int attempts = ATTEMPT_INCREMENT + loginAttemptCache.get(usernameOrEmail);
         if(hasExceededMaxAttempts(attempts)) {
-            throw new AccountNotActiveException("account with username or email" + usernameOrEmail + " has exceeded login attempts.");
+            throw new LockedException("account with username or email" + usernameOrEmail + " has exceeded login attempts.");
         } else {
             loginAttemptCache.put(usernameOrEmail, attempts);
         }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/AccountNotActiveException.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/AccountNotActiveException.java
@@ -1,0 +1,7 @@
+package study.games.flashcard.wars.exception.domain;
+
+public class AccountNotActiveException extends Exception {
+    public AccountNotActiveException(String message) {
+        super(message);
+    }
+}

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/AccountNotActiveException.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/AccountNotActiveException.java
@@ -1,7 +1,0 @@
-package study.games.flashcard.wars.exception.domain;
-
-public class AccountNotActiveException extends Exception {
-    public AccountNotActiveException(String message) {
-        super(message);
-    }
-}

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/ExceptionHandling.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/exception/domain/ExceptionHandling.java
@@ -2,8 +2,7 @@ package study.games.flashcard.wars.exception.domain;
 
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import jakarta.persistence.NoResultException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -19,67 +18,67 @@ import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 
 @ControllerAdvice
+@Slf4j
 public class ExceptionHandling extends ResponseEntityExceptionHandler {
-    private static final Logger logger = LoggerFactory.getLogger(ExceptionHandling.class);
 
     @ExceptionHandler(DisabledException.class)
     public ResponseEntity<Response<String>> accountDisabledException() {
-        logger.error("Attempted login of disabled user");
+        log.error("Attempted login of disabled user");
         return createHttpResponse(HttpStatus.UNAUTHORIZED,
                 "Your account is disabled. If this is a mistake please create a help ticket.");
     }
 
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<Response<String>> badCredentialsException() {
-        logger.error("Attempted login with bad credentials");
+        log.error("Attempted login with bad credentials");
         return createHttpResponse(HttpStatus.FORBIDDEN, "Incorrect username and/or password.");
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Response<String>> accessDeniedException() {
-        logger.error("User attempted to access unauthorized content");
+        log.error("User attempted to access unauthorized content");
         return createHttpResponse(HttpStatus.FORBIDDEN, "You do not have access to this content.");
     }
 
     @ExceptionHandler(LockedException.class)
     public ResponseEntity<Response<String>> lockedException() {
-        logger.error("User with locked account attempted to login");
+        log.error("User with locked account attempted to login");
         return createHttpResponse(HttpStatus.UNAUTHORIZED, "Your account is locked. Please reset password to continue.");
     }
 
     @ExceptionHandler(TokenExpiredException.class)
     public ResponseEntity<Response<String>> tokenExpiredException() {
-        logger.error("User with expired token attempted to access");
+        log.error("User with expired token attempted to access");
         return createHttpResponse(HttpStatus.UNAUTHORIZED, "Your session has expired. Please login to continue.");
     }
 
     @ExceptionHandler(EmailExistsException.class)
     public ResponseEntity<Response<String>> emailExistsException() {
-        logger.warn("User attempted to register with email that is already in use");
+        log.warn("User attempted to register with email that is already in use");
         return createHttpResponse(HttpStatus.UNAUTHORIZED, "An account already exists with this email.");
     }
 
     @ExceptionHandler(UsernameExistsException.class)
     public ResponseEntity<Response<String>> usernameExistsException() {
-        logger.warn("User attempted to register with username that already exists");
+        log.warn("User attempted to register with username that already exists");
         return createHttpResponse(HttpStatus.UNAUTHORIZED, "An account already exists with this username.");
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<String>> internalServerError(Exception e) {
-        logger.error("Internal Server Error", e);
+        log.error("Internal Server Error", e);
         return createHttpResponse(HttpStatus.INTERNAL_SERVER_ERROR, "There was error processing your request.");
     }
 
     @ExceptionHandler(NoResultException.class)
     public ResponseEntity<Response<String>> noResultException(NoResultException e) {
-        logger.error("No Result Exception", e);
+        log.error("No Result Exception", e);
         return createHttpResponse(HttpStatus.NOT_FOUND, "There was error processing your request.");
     }
 
     @ExceptionHandler(IOException.class)
     public ResponseEntity<Response<String>> ioException(IOException e) {
-        logger.error("IO Exception", e);
+        log.error("IO Exception", e);
         return createHttpResponse(HttpStatus.INTERNAL_SERVER_ERROR, "There was error processing your request.");
     }
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -1,6 +1,8 @@
 package study.games.flashcard.wars.listeners;
 
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.LockedException;
@@ -18,15 +20,19 @@ public class AuthenticationFailureListener {
     private final LoginAttemptService loginAttemptService;
     private final UserService userService;
 
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationFailureListener.class);
+
     @EventListener
     public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {
         Object principal = badCredentialsEvent.getAuthentication().getPrincipal();
         if(principal instanceof String username) {
             try {
                 loginAttemptService.addUserToLoginAttemptCache(username);
+                logger.warn("user attempted to login with invalid credentials: " + username);
             } catch (LockedException e) {
                 userService.changeAccountStatus(USER_STATUS.PASSWORD_LOCK, username);
-                throw new AccountExpiredException("account with username or email " + username + " has exceeded login attempts");
+                logger.warn("user's account has been locked: " + username);
+                throw new LockedException("account has exceeded login attempts: " + username);
             }
         }
     }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutionException;
 @Component
 @RequiredArgsConstructor
 public class AuthenticationFailureListener {
-    private LoginAttemptService loginAttemptService;
+    private final LoginAttemptService loginAttemptService;
 
     @EventListener
     public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -3,10 +3,10 @@ package study.games.flashcard.wars.listeners;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.stereotype.Component;
 import study.games.flashcard.wars.auth.services.LoginAttemptService;
-import study.games.flashcard.wars.exception.domain.AccountNotActiveException;
 import study.games.flashcard.wars.models.enums.USER_STATUS;
 import study.games.flashcard.wars.service.UserService;
 
@@ -24,7 +24,7 @@ public class AuthenticationFailureListener {
         if(principal instanceof String username) {
             try {
                 loginAttemptService.addUserToLoginAttemptCache(username);
-            } catch (AccountNotActiveException e) {
+            } catch (LockedException e) {
                 userService.changeAccountStatus(USER_STATUS.PASSWORD_LOCK, username);
                 throw new AccountExpiredException("account with username or email " + username + " has exceeded login attempts");
             }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -1,10 +1,8 @@
 package study.games.flashcard.wars.listeners;
 
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
-import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.stereotype.Component;
@@ -16,11 +14,10 @@ import java.util.concurrent.ExecutionException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AuthenticationFailureListener {
     private final LoginAttemptService loginAttemptService;
     private final UserService userService;
-
-    private static final Logger logger = LoggerFactory.getLogger(AuthenticationFailureListener.class);
 
     @EventListener
     public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {
@@ -28,10 +25,10 @@ public class AuthenticationFailureListener {
         if(principal instanceof String username) {
             try {
                 loginAttemptService.addUserToLoginAttemptCache(username);
-                logger.warn("user attempted to login with invalid credentials: " + username);
+                log.warn("user attempted to login with invalid credentials: " + username);
             } catch (LockedException e) {
                 userService.changeAccountStatus(USER_STATUS.PASSWORD_LOCK, username);
-                logger.warn("user's account has been locked: " + username);
+                log.warn("user's account has been locked: " + username);
                 throw new LockedException("account has exceeded login attempts: " + username);
             }
         }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -2,10 +2,13 @@ package study.games.flashcard.wars.listeners;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.stereotype.Component;
 import study.games.flashcard.wars.auth.services.LoginAttemptService;
 import study.games.flashcard.wars.exception.domain.AccountNotActiveException;
+import study.games.flashcard.wars.models.enums.USER_STATUS;
+import study.games.flashcard.wars.service.UserService;
 
 import java.util.concurrent.ExecutionException;
 
@@ -13,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 @RequiredArgsConstructor
 public class AuthenticationFailureListener {
     private final LoginAttemptService loginAttemptService;
+    private final UserService userService;
 
     @EventListener
     public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {
@@ -21,7 +25,8 @@ public class AuthenticationFailureListener {
             try {
                 loginAttemptService.addUserToLoginAttemptCache(username);
             } catch (AccountNotActiveException e) {
-                // TODO: set account to inactive, inform user
+                userService.changeAccountStatus(USER_STATUS.PASSWORD_LOCK, username);
+                throw new AccountExpiredException("account with username or email " + username + " has exceeded login attempts");
             }
         }
     }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -1,0 +1,23 @@
+package study.games.flashcard.wars.listeners;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
+import org.springframework.stereotype.Component;
+import study.games.flashcard.wars.auth.services.LoginAttemptService;
+
+import java.util.concurrent.ExecutionException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFailureListener {
+    private LoginAttemptService loginAttemptService;
+
+    @EventListener
+    public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {
+        Object principal = badCredentialsEvent.getAuthentication().getPrincipal();
+        if(principal instanceof String username) {
+            loginAttemptService.addUserToLoginAttemptCache(username);
+        }
+    }
+}

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationFailureListener.java
@@ -5,6 +5,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.stereotype.Component;
 import study.games.flashcard.wars.auth.services.LoginAttemptService;
+import study.games.flashcard.wars.exception.domain.AccountNotActiveException;
 
 import java.util.concurrent.ExecutionException;
 
@@ -17,7 +18,11 @@ public class AuthenticationFailureListener {
     public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent badCredentialsEvent) throws ExecutionException {
         Object principal = badCredentialsEvent.getAuthentication().getPrincipal();
         if(principal instanceof String username) {
-            loginAttemptService.addUserToLoginAttemptCache(username);
+            try {
+                loginAttemptService.addUserToLoginAttemptCache(username);
+            } catch (AccountNotActiveException e) {
+                // TODO: set account to inactive, inform user
+            }
         }
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -1,0 +1,23 @@
+package study.games.flashcard.wars.listeners;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.stereotype.Component;
+import study.games.flashcard.wars.auth.services.LoginAttemptService;
+import study.games.flashcard.wars.models.entities.AppUser;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationSuccessListener {
+    private final LoginAttemptService loginAttemptService;
+
+    @EventListener
+    public void onAuthenticationSuccess(AuthenticationSuccessEvent authenticationSuccessEvent) {
+        Object principle = authenticationSuccessEvent.getAuthentication().getPrincipal();
+        if(principle instanceof AppUser user) {
+            loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
+            loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
+        }
+    }
+}

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.stereotype.Component;
+import study.games.flashcard.wars.auth.UserPrinciple;
 import study.games.flashcard.wars.auth.services.LoginAttemptService;
 import study.games.flashcard.wars.models.entities.AppUser;
 import study.games.flashcard.wars.service.UserService;
@@ -19,7 +20,8 @@ public class AuthenticationSuccessListener {
     @EventListener
     public void onAuthenticationSuccess(AuthenticationSuccessEvent authenticationSuccessEvent) {
         Object principle = authenticationSuccessEvent.getAuthentication().getPrincipal();
-        if(principle instanceof AppUser user) {
+        if(principle instanceof UserPrinciple userPrinciple) {
+            AppUser user = userPrinciple.getAppUser();
             loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
             loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
             userService.updateUserLastLoginToNow(user.getId());

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -18,6 +18,7 @@ public class AuthenticationSuccessListener {
         if(principle instanceof AppUser user) {
             loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
             loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
+            // TODO: update the last login date on successful login
         }
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -1,8 +1,7 @@
 package study.games.flashcard.wars.listeners;
 
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.stereotype.Component;
@@ -12,11 +11,10 @@ import study.games.flashcard.wars.service.UserService;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AuthenticationSuccessListener {
     private final LoginAttemptService loginAttemptService;
     private final UserService userService;
-
-    private static final Logger logger = LoggerFactory.getLogger(AuthenticationSuccessListener.class);
 
     @EventListener
     public void onAuthenticationSuccess(AuthenticationSuccessEvent authenticationSuccessEvent) {
@@ -25,7 +23,7 @@ public class AuthenticationSuccessListener {
             loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
             loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
             userService.updateUserLastLoginToNow(user.getId());
-            logger.info("user has successfully logged in: " + user.getUsername());
+            log.info("user has successfully logged in: " + user.getUsername());
         }
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -6,11 +6,13 @@ import org.springframework.security.authentication.event.AuthenticationSuccessEv
 import org.springframework.stereotype.Component;
 import study.games.flashcard.wars.auth.services.LoginAttemptService;
 import study.games.flashcard.wars.models.entities.AppUser;
+import study.games.flashcard.wars.service.UserService;
 
 @Component
 @RequiredArgsConstructor
 public class AuthenticationSuccessListener {
     private final LoginAttemptService loginAttemptService;
+    private final UserService userService;
 
     @EventListener
     public void onAuthenticationSuccess(AuthenticationSuccessEvent authenticationSuccessEvent) {
@@ -18,7 +20,7 @@ public class AuthenticationSuccessListener {
         if(principle instanceof AppUser user) {
             loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
             loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
-            // TODO: update the last login date on successful login
+            userService.updateUserLastLoginToNow(user.getId());
         }
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/listeners/AuthenticationSuccessListener.java
@@ -1,6 +1,8 @@
 package study.games.flashcard.wars.listeners;
 
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,8 @@ public class AuthenticationSuccessListener {
     private final LoginAttemptService loginAttemptService;
     private final UserService userService;
 
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationSuccessListener.class);
+
     @EventListener
     public void onAuthenticationSuccess(AuthenticationSuccessEvent authenticationSuccessEvent) {
         Object principle = authenticationSuccessEvent.getAuthentication().getPrincipal();
@@ -21,6 +25,7 @@ public class AuthenticationSuccessListener {
             loginAttemptService.evictUserFromLoginAttemptCache(user.getUsername());
             loginAttemptService.evictUserFromLoginAttemptCache(user.getEmail());
             userService.updateUserLastLoginToNow(user.getId());
+            logger.info("user has successfully logged in: " + user.getUsername());
         }
     }
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
@@ -13,6 +13,7 @@ import study.games.flashcard.wars.models.enums.USER_STATUS;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -38,10 +39,10 @@ public class AppUser implements Serializable {
     private String firstName;
     private String lastName;
     private String profileImageUrl;
-    private LocalDate lastLoginDate;
-    private LocalDate lastPasswordUpdate;
+    private LocalDateTime lastLoginDate;
+    private LocalDateTime lastPasswordUpdate;
     @CreationTimestamp
-    private LocalDate dateJoined;
+    private LocalDateTime dateJoined;
     @Enumerated(EnumType.STRING)
     private ROLE role;
     @Enumerated(EnumType.STRING)

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
@@ -21,8 +21,9 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @NamedQuery(name = "AppUser.findAppUserByUsernameOrEmail",
-        query = "select e from AppUser e where e.username = :USERNAME_EMAIL or e.username = :USERNAME_EMAIL")
-@NamedQuery(name = "AppUser.updateUserStatus", query = "update AppUser user set user.status = :STATUS where user.id = :ID")
+        query = "select user from AppUser user where user.username = :USERNAME_EMAIL or user.username = :USERNAME_EMAIL")
+@NamedQuery(name = "AppUser.updateUserStatus",
+        query = "update AppUser user set user.status = :STATUS where user.username = :USERNAME_EMAIL or user.username = :USERNAME_EMAIL")
 @NamedQuery(name = "AppUser.setLastLoginDate", query = "update AppUser user set user.lastLoginDate = :LOGIN_DATE where user.id = :ID")
 public class AppUser implements Serializable {
     @Id

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
@@ -22,6 +22,8 @@ import java.util.List;
 @Entity
 @NamedQuery(name = "AppUser.findAppUserByUsernameOrEmail",
         query = "select e from AppUser e where e.username = :USERNAME_EMAIL or e.username = :USERNAME_EMAIL")
+@NamedQuery(name = "AppUser.updateUserStatus", query = "update AppUser user set user.status = :STATUS where user.id = :ID")
+@NamedQuery(name = "AppUser.setLastLoginDate", query = "update AppUser user set user.lastLoginDate = :LOGIN_DATE where user.id = :ID")
 public class AppUser implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/models/entities/AppUser.java
@@ -21,9 +21,9 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @NamedQuery(name = "AppUser.findAppUserByUsernameOrEmail",
-        query = "select user from AppUser user where user.username = :USERNAME_EMAIL or user.username = :USERNAME_EMAIL")
+        query = "select user from AppUser user where user.username = :USERNAME_EMAIL or user.email = :USERNAME_EMAIL")
 @NamedQuery(name = "AppUser.updateUserStatus",
-        query = "update AppUser user set user.status = :STATUS where user.username = :USERNAME_EMAIL or user.username = :USERNAME_EMAIL")
+        query = "update AppUser user set user.status = :STATUS where user.username = :USERNAME_EMAIL or user.email = :USERNAME_EMAIL")
 @NamedQuery(name = "AppUser.setLastLoginDate", query = "update AppUser user set user.lastLoginDate = :LOGIN_DATE where user.id = :ID")
 public class AppUser implements Serializable {
     @Id
@@ -42,7 +42,10 @@ public class AppUser implements Serializable {
     private LocalDate lastPasswordUpdate;
     @CreationTimestamp
     private LocalDate dateJoined;
+    @Enumerated(EnumType.STRING)
     private ROLE role;
+    @Enumerated(EnumType.STRING)
     private USER_STATUS status;
+    @Transient
     private List<PERMISSION> authorities;
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
@@ -1,7 +1,7 @@
 package study.games.flashcard.wars.repository;
 
-import org.hibernate.annotations.NamedNativeQuery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 import study.games.flashcard.wars.models.entities.AppUser;
 import study.games.flashcard.wars.models.enums.USER_STATUS;
@@ -16,7 +16,9 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
 
     AppUser findAppUserByEmail(String email);
 
+    @Modifying
     int updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("USERNAME_EMAIL") String usernameOrEmail);
 
+    @Modifying
     void setLastLoginDate(@Param("LOGIN_DATE") LocalDate loginDate, long userId);
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
@@ -21,5 +21,5 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
     void updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("USERNAME_EMAIL") String usernameOrEmail);
 
     @Modifying
-    void setLastLoginDate(@Param("LOGIN_DATE") LocalDateTime loginDate, long userId);
+    void setLastLoginDate(@Param("LOGIN_DATE") LocalDateTime loginDate, @Param("ID") long userId);
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
@@ -4,7 +4,9 @@ import org.hibernate.annotations.NamedNativeQuery;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import study.games.flashcard.wars.models.entities.AppUser;
+import study.games.flashcard.wars.models.enums.USER_STATUS;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<AppUser, Long> {
@@ -13,4 +15,8 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
     Optional<AppUser> findAppUserByUsernameOrEmail(@Param("USERNAME_EMAIL") String userNameOrEmail);
 
     AppUser findAppUserByEmail(String email);
+
+    int updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("ID") long userId);
+
+    int setLastLoginDate(@Param("LOGIN_DATE") LocalDate loginDate, long userId);
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
@@ -16,7 +16,7 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
 
     AppUser findAppUserByEmail(String email);
 
-    int updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("ID") long userId);
+    int updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("USERNAME_EMAIL") String usernameOrEmail);
 
-    int setLastLoginDate(@Param("LOGIN_DATE") LocalDate loginDate, long userId);
+    void setLastLoginDate(@Param("LOGIN_DATE") LocalDate loginDate, long userId);
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/repository/UserRepository.java
@@ -7,6 +7,7 @@ import study.games.flashcard.wars.models.entities.AppUser;
 import study.games.flashcard.wars.models.enums.USER_STATUS;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<AppUser, Long> {
@@ -17,8 +18,8 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
     AppUser findAppUserByEmail(String email);
 
     @Modifying
-    int updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("USERNAME_EMAIL") String usernameOrEmail);
+    void updateUserStatus(@Param("STATUS") USER_STATUS status, @Param("USERNAME_EMAIL") String usernameOrEmail);
 
     @Modifying
-    void setLastLoginDate(@Param("LOGIN_DATE") LocalDate loginDate, long userId);
+    void setLastLoginDate(@Param("LOGIN_DATE") LocalDateTime loginDate, long userId);
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/resource/UserResource.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/resource/UserResource.java
@@ -4,17 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import study.games.flashcard.wars.auth.AuthenticationService;
-import study.games.flashcard.wars.models.dtos.Response;
+import study.games.flashcard.wars.auth.services.AuthenticationService;
 import study.games.flashcard.wars.models.dtos.UserDto;
 import study.games.flashcard.wars.models.entities.AppUser;
-
-import java.time.LocalDateTime;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
-import static study.games.flashcard.wars.auth.SecurityConstants.JWT_HEADER;
 
 @RequiredArgsConstructor
 @RestController

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
@@ -21,7 +21,7 @@ public interface UserService {
 
     List<AppUser> getAllUsers();
 
-    boolean changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail);
+    void changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail);
 
     void updateUserLastLoginToNow(long userId);
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
@@ -1,6 +1,7 @@
 package study.games.flashcard.wars.service;
 
 import study.games.flashcard.wars.models.entities.AppUser;
+import study.games.flashcard.wars.models.enums.USER_STATUS;
 
 import java.util.List;
 
@@ -19,6 +20,10 @@ public interface UserService {
     AppUser updateUser(AppUser appUser);
 
     List<AppUser> getAllUsers();
+
+    boolean changeAccountStatus(USER_STATUS userStatus, long userId);
+
+    void updateUserLastLoginToNow(long userId);
 
 
 }

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/UserService.java
@@ -21,7 +21,7 @@ public interface UserService {
 
     List<AppUser> getAllUsers();
 
-    boolean changeAccountStatus(USER_STATUS userStatus, long userId);
+    boolean changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail);
 
     void updateUserLastLoginToNow(long userId);
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
@@ -4,9 +4,11 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import study.games.flashcard.wars.models.entities.AppUser;
+import study.games.flashcard.wars.models.enums.USER_STATUS;
 import study.games.flashcard.wars.repository.UserRepository;
 import study.games.flashcard.wars.service.UserService;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -49,6 +51,17 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<AppUser> getAllUsers() {
         return userRepo.findAll();
+    }
+
+    @Override
+    public boolean changeAccountStatus(USER_STATUS userStatus, long userId) {
+        int rows = userRepo.updateUserStatus(userStatus, userId);
+        return rows != 0;
+    }
+
+    @Override
+    public void updateUserLastLoginToNow(long userId) {
+        userRepo.setLastLoginDate(LocalDate.now(), userId);
     }
 
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
@@ -54,8 +54,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean changeAccountStatus(USER_STATUS userStatus, long userId) {
-        int rows = userRepo.updateUserStatus(userStatus, userId);
+    public boolean changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail) {
+        int rows = userRepo.updateUserStatus(userStatus, usernameOrEmail);
         return rows != 0;
     }
 

--- a/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
+++ b/flashcard.wars/src/main/java/study/games/flashcard/wars/service/impl/UserServiceImpl.java
@@ -9,6 +9,7 @@ import study.games.flashcard.wars.repository.UserRepository;
 import study.games.flashcard.wars.service.UserService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -54,14 +55,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail) {
-        int rows = userRepo.updateUserStatus(userStatus, usernameOrEmail);
-        return rows != 0;
+    public void changeAccountStatus(USER_STATUS userStatus, String usernameOrEmail) {
+        userRepo.updateUserStatus(userStatus, usernameOrEmail);
     }
 
     @Override
     public void updateUserLastLoginToNow(long userId) {
-        userRepo.setLastLoginDate(LocalDate.now(), userId);
+        userRepo.setLastLoginDate(LocalDateTime.now(), userId);
     }
 
 


### PR DESCRIPTION
* Add a login attempt cache to keep track of users who have logged in with incorrect password
* Add a listener for bad authentication attempts and lock the account after five tries
* Add a listener for successful authentication and update the users last login date